### PR TITLE
Upgrade to latest kamu and remove local workspace mode

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
-      - run: cargo install --locked cargo-deny
+      - run: cargo install cargo-deny
       - run: cargo deny check
 
   test_linux:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,8 +1320,8 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "container-runtime"
-version = "0.132.3"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.132.3#ea57c8f5f13e6a6f3c652aec21f57affce11489f"
+version = "0.133.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=feature/engine-io-proxy#93a0dd95e67cd1be0255033dd49f74ebd6527717"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1811,8 +1811,8 @@ dependencies = [
 
 [[package]]
 name = "enum-variants"
-version = "0.132.3"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.132.3#ea57c8f5f13e6a6f3c652aec21f57affce11489f"
+version = "0.133.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=feature/engine-io-proxy#93a0dd95e67cd1be0255033dd49f74ebd6527717"
 
 [[package]]
 name = "env_logger"
@@ -1856,8 +1856,8 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing"
-version = "0.132.3"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.132.3#ea57c8f5f13e6a6f3c652aec21f57affce11489f"
+version = "0.133.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=feature/engine-io-proxy#93a0dd95e67cd1be0255033dd49f74ebd6527717"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1870,8 +1870,8 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.132.3"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.132.3#ea57c8f5f13e6a6f3c652aec21f57affce11489f"
+version = "0.133.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=feature/engine-io-proxy#93a0dd95e67cd1be0255033dd49f74ebd6527717"
 dependencies = [
  "quote",
  "syn 2.0.27",
@@ -2437,8 +2437,8 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.132.3"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.132.3#ea57c8f5f13e6a6f3c652aec21f57affce11489f"
+version = "0.133.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=feature/engine-io-proxy#93a0dd95e67cd1be0255033dd49f74ebd6527717"
 dependencies = [
  "thiserror",
 ]
@@ -2516,8 +2516,8 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.132.3"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.132.3#ea57c8f5f13e6a6f3c652aec21f57affce11489f"
+version = "0.133.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=feature/engine-io-proxy#93a0dd95e67cd1be0255033dd49f74ebd6527717"
 dependencies = [
  "async-recursion",
  "async-stream",
@@ -2575,8 +2575,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.132.3"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.132.3#ea57c8f5f13e6a6f3c652aec21f57affce11489f"
+version = "0.133.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=feature/engine-io-proxy#93a0dd95e67cd1be0255033dd49f74ebd6527717"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -2598,8 +2598,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.132.3"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.132.3#ea57c8f5f13e6a6f3c652aec21f57affce11489f"
+version = "0.133.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=feature/engine-io-proxy#93a0dd95e67cd1be0255033dd49f74ebd6527717"
 dependencies = [
  "async-trait",
  "axum",
@@ -2670,8 +2670,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.132.3"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.132.3#ea57c8f5f13e6a6f3c652aec21f57affce11489f"
+version = "0.133.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=feature/engine-io-proxy#93a0dd95e67cd1be0255033dd49f74ebd6527717"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2696,8 +2696,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-data-utils"
-version = "0.132.3"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.132.3#ea57c8f5f13e6a6f3c652aec21f57affce11489f"
+version = "0.133.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=feature/engine-io-proxy#93a0dd95e67cd1be0255033dd49f74ebd6527717"
 dependencies = [
  "arrow-digest",
  "datafusion",
@@ -2725,8 +2725,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.132.3"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.132.3#ea57c8f5f13e6a6f3c652aec21f57affce11489f"
+version = "0.133.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=feature/engine-io-proxy#93a0dd95e67cd1be0255033dd49f74ebd6527717"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2745,8 +2745,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.132.3"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.132.3#ea57c8f5f13e6a6f3c652aec21f57affce11489f"
+version = "0.133.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=feature/engine-io-proxy#93a0dd95e67cd1be0255033dd49f74ebd6527717"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3157,8 +3157,8 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opendatafabric"
-version = "0.132.3"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.132.3#ea57c8f5f13e6a6f3c652aec21f57affce11489f"
+version = "0.133.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=feature/engine-io-proxy#93a0dd95e67cd1be0255033dd49f74ebd6527717"
 dependencies = [
  "bs58",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 
 [workspace.dependencies]
 # Utils
-container-runtime = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.132.3", version = "0.132.3", default-features = false }
-internal-error = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.132.3", version = "0.132.3", default-features = false }
+container-runtime = { git = "https://github.com/kamu-data/kamu-cli", branch = "feature/engine-io-proxy", version = "0.133.0", default-features = false }
+internal-error = { git = "https://github.com/kamu-data/kamu-cli", branch = "feature/engine-io-proxy", version = "0.133.0", default-features = false }
 # Domain
-opendatafabric = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.132.3", version = "0.132.3", default-features = false }
-kamu-task-system = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.132.3", version = "0.132.3", default-features = false }
+opendatafabric = { git = "https://github.com/kamu-data/kamu-cli", branch = "feature/engine-io-proxy", version = "0.133.0", default-features = false }
+kamu-task-system = { git = "https://github.com/kamu-data/kamu-cli", branch = "feature/engine-io-proxy", version = "0.133.0", default-features = false }
 # Infra
-kamu = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.132.3", version = "0.132.3", default-features = false }
-kamu-task-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.132.3", version = "0.132.3", default-features = false }
-kamu-adapter-graphql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.132.3", version = "0.132.3", default-features = false }
-kamu-adapter-http = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.132.3", version = "0.132.3", default-features = false }
+kamu = { git = "https://github.com/kamu-data/kamu-cli", branch = "feature/engine-io-proxy", version = "0.133.0", default-features = false }
+kamu-task-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "feature/engine-io-proxy", version = "0.133.0", default-features = false }
+kamu-adapter-graphql = { git = "https://github.com/kamu-data/kamu-cli", branch = "feature/engine-io-proxy", version = "0.133.0", default-features = false }
+kamu-adapter-http = { git = "https://github.com/kamu-data/kamu-cli", branch = "feature/engine-io-proxy", version = "0.133.0", default-features = false }
 
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Prerequisites:
 To run API server using local `kamu` workspace:
 
 ```bash
-cargo run -- --local-repo /home/me/workspace/.kamu run | bunyan
+cargo run -- --repo-url workspace/.kamu/datasets run | bunyan
 ```
 
 To control log verbosity use the standard `RUST_LOG` env var:

--- a/src/app/api-server/Cargo.toml
+++ b/src/app/api-server/Cargo.toml
@@ -55,13 +55,13 @@ futures = "0.3"
 indoc = "2"
 serde = "1"
 serde_json = "1"
+tempfile = "3"
 tokio = { version = "1", default-features = false, features = ["macros"] }
 tokio-util = { version = "0.7", default-features = false, features = ["rt"] }
 url = "2"
 
 
 [dev-dependencies]
-tempfile = "3"
 rand = "0.8"
 env_logger = "0.10"
 test-group = { version = "1" }

--- a/src/app/api-server/tests/tests/test_di_graph.rs
+++ b/src/app/api-server/tests/tests/test_di_graph.rs
@@ -12,11 +12,9 @@ use dill::*;
 #[test_log::test(tokio::test)]
 async fn test_di_graph_validates_local() {
     let tempdir = tempfile::tempdir().unwrap();
-    let workspace_layout =
-        kamu::WorkspaceLayout::create(tempdir.path().to_path_buf(), false).unwrap();
-
     let mut catalog_builder = kamu_api_server::init_dependencies(
-        kamu_api_server::RunMode::LocalWorkspace(workspace_layout),
+        &url::Url::from_directory_path(tempdir.path()).unwrap(),
+        tempdir.path(),
     )
     .await;
 
@@ -25,7 +23,6 @@ async fn test_di_graph_validates_local() {
     // manually
     let validate_result = catalog_builder
         .validate()
-        .ignore::<kamu::WorkspaceLayout>()
         .ignore::<dyn kamu::domain::DatasetRepository>();
 
     assert!(
@@ -57,14 +54,13 @@ async fn test_di_graph_validates_remote() {
     .unwrap();
 
     let mut catalog_builder =
-        kamu_api_server::init_dependencies(kamu_api_server::RunMode::RemoteS3Url(repo_url)).await;
+        kamu_api_server::init_dependencies(&repo_url, tmp_repo_dir.path()).await;
 
     // TODO: We should ensure this test covers parameters requested by commands and
     // types needed for GQL/HTTP adapter that are currently being constructed
     // manually
     let validate_result = catalog_builder
         .validate()
-        .ignore::<kamu::WorkspaceLayout>()
         .ignore::<dyn kamu::domain::DatasetRepository>();
 
     assert!(


### PR DESCRIPTION
In this PR:
- I get rid of loca/remote modes - now you can just start the server with a local path (pointing to `.kamu/datasets` or an S3 URL
- Server will create a temp directory for engine logs, input data, etc.
- Ingest/transform should now work even with S3 repo