### PR TITLE
Add app config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.0] - 2023-10-26
+## [0.10.0] - 2023-10-29
+### Added
+- Introduced a config file allowing to configure the list of supported auth providers
+
+## [0.9.0] - 2023-10-26
 ### Added
 - FlightSQL endpoint
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,6 +595,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1181,12 @@ name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "bytemuck"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
 name = "byteorder"
@@ -1990,6 +2005,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
 
 [[package]]
+name = "figment"
+version = "0.10.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a014ac935975a70ad13a3bff2463b1c1b083b35ae4cb6309cfc59476aa7a181f"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2531,6 +2561,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-api-server"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "arrow-flight",
  "async-graphql",
@@ -2828,6 +2864,7 @@ dependencies = [
  "datafusion",
  "dill",
  "env_logger",
+ "figment",
  "futures",
  "http",
  "hyper",
@@ -2939,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3643,6 +3680,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pear"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a386cd715229d399604b50d1361683fe687066f42d56f54be995bc6868f71c"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi 1.0.0-rc.1",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f0f13dac8069c139e8300a6510e3f4143ecf5259c60b116a9b271b4ca0d54"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "pem"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3884,7 +3944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
 dependencies = [
  "diff",
- "yansi",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -3904,6 +3964,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+ "version_check",
+ "yansi 1.0.0-rc.1",
 ]
 
 [[package]]
@@ -5302,6 +5375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
+name = "uncased"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9bc53168a4be7402ab86c3aad243a84dd7381d09be0eddc81280c1da95ca68"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5711,6 +5793,12 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ kamu-adapter-flight-sql = { git = "https://github.com/kamu-data/kamu-cli", tag =
 
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 homepage = "https://github.com/kamu-data/kamu-platform"
 repository = "https://github.com/kamu-data/kamu-platform"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -24,7 +24,7 @@ Additional Use Grant:      You may use the Licensed Work for any purpose,
                            Licensed Work where data or transformations are
                            controlled by such third parties.
 
-Change Date:               2027-10-26
+Change Date:               2027-10-29
 
 Change License:            Apache License, Version 2.0
 

--- a/src/app/api-server/Cargo.toml
+++ b/src/app/api-server/Cargo.toml
@@ -59,9 +59,10 @@ async-trait = { version = "0.1", default-features = false }
 chrono = "0.4"
 clap = "4"
 datafusion = "31"
+figment = { version = "0.10", features = ["env", "yaml", "json"] }
 futures = "0.3"
 indoc = "2"
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", default-features = false, features = ["macros"] }

--- a/src/app/api-server/src/cli_parser.rs
+++ b/src/app/api-server/src/cli_parser.rs
@@ -24,10 +24,16 @@ pub fn cli() -> Command {
               kamu-api-server <command> <sub-command> -h
             "
         ))
-        .args([Arg::new("repo-url")
-            .long("repo-url")
-            .value_parser(value_parse_repo_url)
-            .help("URL of the remote dataset repository")])
+        .args([
+            Arg::new("config")
+                .long("config")
+                .value_parser(value_parser!(std::path::PathBuf))
+                .help("Path to the config file"),
+            Arg::new("repo-url")
+                .long("repo-url")
+                .value_parser(value_parse_repo_url)
+                .help("URL of the remote dataset repository"),
+        ])
         .subcommands([
             Command::new("run").about("Run the server").args([
                 Arg::new("address")

--- a/src/app/api-server/src/config.rs
+++ b/src/app/api-server/src/config.rs
@@ -1,0 +1,50 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use serde::{Deserialize, Serialize};
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiServerConfig {
+    pub auth: AuthConfig,
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthConfig {
+    pub providers: Vec<AuthProviderConfig>,
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(tag = "kind")]
+pub enum AuthProviderConfig {
+    Github(AuthProviderConfigGitHub),
+    Dummy(AuthProviderConfigDummy),
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthProviderConfigGitHub {}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthProviderConfigDummy {
+    pub accounts: Vec<kamu::domain::auth::AccountInfo>,
+}

--- a/src/app/api-server/src/lib.rs
+++ b/src/app/api-server/src/lib.rs
@@ -8,8 +8,9 @@
 // by the Apache License, Version 2.0.
 
 pub(crate) mod app;
-pub(crate) mod builtin_authentication_provider;
 pub(crate) mod cli_parser;
+pub mod config;
+pub(crate) mod dummy_auth_provider;
 pub(crate) mod flightsql_server;
 pub(crate) mod gql_server;
 pub(crate) mod http_server;

--- a/src/app/api-server/src/main.rs
+++ b/src/app/api-server/src/main.rs
@@ -13,6 +13,9 @@ async fn main() {
 
     match kamu_api_server::run(matches).await {
         Ok(_) => {}
-        Err(_) => std::process::exit(1),
+        Err(err) => {
+            eprintln!("Error: {:#?}", err);
+            std::process::exit(1)
+        }
     }
 }

--- a/src/app/api-server/tests/tests/test_di_graph.rs
+++ b/src/app/api-server/tests/tests/test_di_graph.rs
@@ -13,6 +13,7 @@ use dill::*;
 async fn test_di_graph_validates_local() {
     let tempdir = tempfile::tempdir().unwrap();
     let mut catalog_builder = kamu_api_server::init_dependencies(
+        kamu_api_server::config::ApiServerConfig::default(),
         &url::Url::from_directory_path(tempdir.path()).unwrap(),
         tempdir.path(),
     )
@@ -57,8 +58,12 @@ async fn test_di_graph_validates_remote() {
     ))
     .unwrap();
 
-    let mut catalog_builder =
-        kamu_api_server::init_dependencies(&repo_url, tmp_repo_dir.path()).await;
+    let mut catalog_builder = kamu_api_server::init_dependencies(
+        kamu_api_server::config::ApiServerConfig::default(),
+        &repo_url,
+        tmp_repo_dir.path(),
+    )
+    .await;
 
     // CurrentAccountSubject is inserted by middlewares, but won't be present in
     // default dependency graph, so we have to add it manually


### PR DESCRIPTION
I used a crate called [figment](https://crates.io/crates/figment) that allows layered config loading / merging.

It allows me to specify a config like:
```yaml
auth:
  providers:
    - kind: dummy
      accounts:
        - accountId: "0"
          accountType: User
          accountName: kamu
          displayName: kamu
          avatarUrl: https://avatars.githubusercontent.com/u/50896974?s=200&v=4
```

Config can also be overridden with env vars, e.g. `KAMU_API_SERVER_FOO=x`.